### PR TITLE
Add dropout mutator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ __pycache__/
 # C extensions
 *.so
 
+# Data
+nltk_data
+
 # Distribution / packaging
 .Python
 build/

--- a/mutatest/dropout_mutator.py
+++ b/mutatest/dropout_mutator.py
@@ -1,1 +1,51 @@
-# TODO
+from typing import Tuple, List, Callable
+from Word import Word
+from nltk.tokenize import word_tokenize
+import nltk
+import random as random_pkg
+from random import Random
+from itertools import combinations
+
+def mutate_by_dropout(input_sentence: str,
+                        num_dropouts: int = 1,
+                        random_seed: int = 13) -> List[str]:
+    """
+    Returns a list of mutated version of the given input sentence by removing some important words.
+
+            Parameters:
+                ``input_sentence`` (``str``): the input sentence
+
+                ``num_dropouts`` (``int``): the number of words that should be dropped out per
+                output sentence
+
+                ``random_seed`` (``int``):
+
+            Returns:
+                A list mutated sentences.
+    """
+    # Set thread safe seed for reproducibility
+    rng = random_pkg.Random()
+    rng.seed(a=random_seed)
+
+    tokens = word_tokenize(input_sentence)
+    tokens_with_pos_tags = nltk.pos_tag(tokens)
+    words = [Word.from_tuple(t) for t in tokens_with_pos_tags]
+    non_stopword_list = {word.value for word in words if not word.is_stopword}
+
+    mutated_sentences = []    
+    for subset in combinations(non_stopword_list, num_dropouts):
+        sentence = [word.value for word in words]
+        for remove_word in subset:
+            sentence.remove(remove_word)
+        mutated_sentences.append(" ".join(sentence))
+
+    return mutated_sentences
+
+if __name__ == "__main__":
+    test_sentence = "Uploading files via JSON Post request to a Web Service provided by Teambox"
+    result = mutate_by_dropout(test_sentence,
+                                   num_dropouts=2)
+    print(f"ORIGINAL: \n{test_sentence}")
+    print("VARIANTS:")
+    for x in result:
+        print(x)

--- a/mutatest/mutators.py
+++ b/mutatest/mutators.py
@@ -1,6 +1,7 @@
 from abc import ABC, abstractmethod
 from typing import List
 from replacement_mutator import mutate_by_replacement
+from dropout_mutator import mutate_by_dropout
 
 
 class Mutator(ABC):
@@ -42,6 +43,15 @@ class ReplacementMutator(Mutator):
 
 class DropoutMutator(Mutator):
 
+    def __init__(self,
+                 num_dropouts: int = 1):
+        """
+        TODO comment (get from function)
+        """
+        self.num_dropouts = num_dropouts
+
     def mutate(self, input_sentence: str, random_seed: int) -> List[str]:
         # TODO
-        pass
+        return mutate_by_dropout(input_sentence,
+                                    num_dropouts=self.num_dropouts,
+                                    random_seed=random_seed)


### PR DESCRIPTION
The number of words to be removed can be changed. Now it is set to num_dropouts=2. 

The mutator just finds all possible combinations of the words (excluding stopwords) and creates a new mutated sentence for each different combination of words.